### PR TITLE
Fix incorrect installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ via `--max-unpack-length` option.
 
 ## Installation
 
-    pip install flake8-tuple-unpack-length
+    pip install flake8-tuple-unpack-limit
 
 
 ## Example


### PR DESCRIPTION
It seems that this checker is named `flake8-tuple-unpack-limit` on PyPI.